### PR TITLE
Fluentd syslog forwarder (e.g. to papertrail)

### DIFF
--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -83,3 +83,23 @@ $ kontena stack install kontena/fluentd-elasticsearch
 ```
 $ kontena grid update --log-forwarder fluentd --log-opt fluentd-address=localhost ${GRID}
 ```
+
+## Syslog
+
+Fluentd agent forwards to various syslog collectors using TLS (only). This enables log output to [Papertrail](https://papertrailapp.com).
+
+### installation
+
+```
+$ kontena stack install kontena/fluentd-syslog-tls
+> Remote syslog host : <e.g. your papertrail host>
+> Remote syslog port : <e.g. your papertrail port>
+```
+
+You will be asked for syslog host and port.
+
+### Grid Configuration
+
+```
+$ kontena grid update --log-forwarder fluentd --log-opt fluentd-address=localhost ${GRID}
+```

--- a/fluentd/syslog-tls/Dockerfile
+++ b/fluentd/syslog-tls/Dockerfile
@@ -1,0 +1,13 @@
+FROM fluent/fluentd:v0.14
+#-onbuild
+
+RUN apk add --update --virtual .build-deps \
+        sudo build-base ruby-dev \
+    && sudo gem install --no-document fluent-plugin-syslog-tls \
+    && sudo gem sources --clear-all \
+    && apk del .build-deps \
+    && apk add curl \
+    && rm -rf /var/cache/apk/* \
+            /home/fluent/.gem/ruby/2.3.0/cache/*.gem
+
+COPY fluent.conf /fluentd/etc/

--- a/fluentd/syslog-tls/fluent.conf
+++ b/fluentd/syslog-tls/fluent.conf
@@ -1,0 +1,39 @@
+<source>
+  @type  forward
+  port  24224
+</source>
+
+<filter **>
+  @type record_transformer
+  enable_ruby
+  <record>
+    severity ${'stdout' == record['source'] ? 'info' : 'err'}
+    hostname ${tag_parts[0]}.${tag_parts[1]}
+    app_name ${tag_parts[2]}.${tag_parts[3]}.${tag_parts[4]}
+  </record>
+</filter>
+
+<match>
+  @type syslog_tls
+  host "#{ENV['SYSLOG_HOST']}"
+  port "#{ENV['SYSLOG_PORT']}"
+  idle_timeout 720
+
+  # hostname static-hostname
+  # facility SYSLOG
+
+  # You can configure syslog headers to be picked from actual message
+  # processed by plugin. If key is not provided '-' value will be sent
+  # which is NIL by syslog specification.
+  severity_key severity
+  # facility_key RECORD_FACILITY_KEY
+  hostname_key hostname
+  app_name_key app_name
+  # procid_key   procid
+  # msgid_key ...
+
+  # Fluent's standard formatting options are supported. Default is 'json'.
+  # Example: For Docker logs sent to Papertrail, send only the log text:
+  format single_value
+  message_key log
+</match>

--- a/fluentd/syslog-tls/kontena.yml
+++ b/fluentd/syslog-tls/kontena.yml
@@ -1,0 +1,26 @@
+stack: kontena/fluentd-syslog-tls
+version: 0.1.0
+description: Fluent forwarding using fluentd-syslog-tls plugin
+variables:
+  host:
+    type: string
+    from:
+      prompt: Remote syslog host
+  port:
+    type: integer
+    from:
+      prompt: Remote syslog port
+
+services:
+  agent:
+    build: .
+    image: kdgm/fluentd-syslog-tls:latest
+    environment:
+      SYSLOG_HOST: {{ host }}
+      SYSLOG_PORT: {{ port }}
+    ports:
+      - 24224:24224
+    deploy:
+      strategy: daemon
+    mem_limit: 128m
+    cpu_shares: 256


### PR DESCRIPTION
Kontena stack based on fluentd-syslog-tls plugin to forward logging e.g. to Papertrail.