### PR TITLE
[ingress-lb] Allow using wildcard certificates

### DIFF
--- a/ingress-lb/kontena.yml
+++ b/ingress-lb/kontena.yml
@@ -56,10 +56,11 @@ services:
     # {% if lb_certs.size > 0 %}
     certificates:
       # {% for subject in lb_certs %}
-      - subject: {{ subject }}
+      - subject: "{{ subject }}"
         name: "SSL_CERT_{{ subject }}"
         type: env
       # {% endfor %}
     # {% else %}
     certificates: []
     # {% endif %}
+


### PR DESCRIPTION
Before this fix I got this error when upgrading the ingress lb and selecting a wildcard certificate (manually generated from Let's Encrypt with certbot):
```
DEBUG [Response]: Headers: {Content-Type: application/json, X-Kontena-Version: 1.5.4}  | Status: 200 | Body: "{\"id\":\"demo/LB_STATS_PASSWORD\",\"name\":\"LB_STATS_PASSWORD\",\"created_at\..."
DEBUG Execution took 15.298 seconds
DEBUG Psych::SyntaxError
Traceback (most recent call last):
	17: from /usr/local/bin/kontena:23:in `<main>'
	16: from /usr/local/bin/kontena:23:in `load'
	15: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/bin/kontena:22:in `<top (required)>'
	14: from /var/lib/gems/2.5.0/gems/clamp-1.2.1/lib/clamp/command.rb:132:in `run'
	13: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/command.rb:216:in `run'
	12: from /var/lib/gems/2.5.0/gems/clamp-1.2.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	11: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/command.rb:216:in `run'
	10: from /var/lib/gems/2.5.0/gems/clamp-1.2.1/lib/clamp/subcommand/execution.rb:11:in `execute'
	 9: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/command.rb:216:in `run'
	 8: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/upgrade_command.rb:52:in `execute'
	 7: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/upgrade_command.rb:92:in `process_data'
	 6: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/upgrade_command.rb:92:in `reverse_each'
	 5: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/upgrade_command.rb:94:in `block in process_data'
	 4: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/upgrade_command.rb:121:in `process_stack_data'
	 3: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/yaml/reader.rb:202:in `execute'
	 2: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/yaml/reader.rb:255:in `validate'
	 1: from /var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/yaml/reader.rb:95:in `fully_interpolated_yaml'
/var/lib/gems/2.5.0/gems/kontena-cli-1.5.4/lib/kontena/cli/stacks/yaml/reader.rb:110:in `rescue in fully_interpolated_yaml': Error while parsing kontena/ingress-lb : (kontena/ingress-lb): did not find expected alphabetic or numeric character while scanning an alias at line 57 column 18 (Psych::SyntaxError)
```

This is because the `subject` variable was used without the quote marks and that makes the stack file yaml invalid.